### PR TITLE
test: add failing tests exposing 6 bugs

### DIFF
--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -99,6 +99,7 @@
         <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
+            <version>1.18.34</version>
             <optional>true</optional>
         </dependency>
 
@@ -130,6 +131,19 @@
 
     <build>
         <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <annotationProcessorPaths>
+                        <path>
+                            <groupId>org.projectlombok</groupId>
+                            <artifactId>lombok</artifactId>
+                            <version>1.18.34</version>
+                        </path>
+                    </annotationProcessorPaths>
+                </configuration>
+            </plugin>
             <plugin>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>

--- a/backend/src/test/java/com/flowboard/service/ApprovalServiceBugTest.java
+++ b/backend/src/test/java/com/flowboard/service/ApprovalServiceBugTest.java
@@ -1,0 +1,157 @@
+package com.flowboard.service;
+
+import com.flowboard.dto.SubmitApprovalRequest;
+import com.flowboard.entity.*;
+import com.flowboard.repository.*;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+/**
+ * Bug-finding tests for ApprovalService.
+ *
+ * BUG: submitApproval() calls approveAllSummaryItems() immediately when a
+ * SINGLE user approves (line 68-69), even though the consensus model documented
+ * at line 124 says "all must approve". This means action items and decisions
+ * are marked APPROVED after just one person approves, before the rest of the
+ * team has responded.
+ */
+@ExtendWith(MockitoExtension.class)
+class ApprovalServiceBugTest {
+
+    @Mock private ApprovalRequestSummaryRepository approvalRequestRepository;
+    @Mock private ApprovalResponseSummaryRepository approvalResponseRepository;
+    @Mock private MeetingRepository meetingRepository;
+    @Mock private MeetingMemberRepository meetingMemberRepository;
+    @Mock private ActionItemRepository actionItemRepository;
+    @Mock private DecisionRepository decisionRepository;
+
+    private ApprovalService approvalService;
+
+    private UUID meetingId;
+    private Meeting meeting;
+    private User user1;
+    private User user2;
+    private ApprovalRequestSummary approvalRequest;
+    private ActionItem actionItem;
+    private Decision decision;
+
+    @BeforeEach
+    void setUp() {
+        approvalService = new ApprovalService(
+            approvalRequestRepository,
+            approvalResponseRepository,
+            meetingRepository,
+            meetingMemberRepository,
+            actionItemRepository,
+            decisionRepository
+        );
+
+        meetingId = UUID.randomUUID();
+        UUID projectId = UUID.randomUUID();
+
+        user1 = User.builder().id(UUID.randomUUID()).username("user1").email("user1@test.com").build();
+        user2 = User.builder().id(UUID.randomUUID()).username("user2").email("user2@test.com").build();
+
+        Project project = Project.builder().id(projectId).name("Test").owner(user1).build();
+
+        meeting = Meeting.builder()
+            .id(meetingId)
+            .project(project)
+            .title("Sprint Planning")
+            .status(Meeting.MeetingStatus.PENDING_APPROVAL)
+            .createdBy(user1)
+            .build();
+
+        approvalRequest = ApprovalRequestSummary.builder()
+            .id(UUID.randomUUID())
+            .meeting(meeting)
+            .requiredApprovals(2)
+            .build();
+
+        actionItem = ActionItem.builder()
+            .id(UUID.randomUUID())
+            .meeting(meeting)
+            .description("Implement feature X")
+            .approvalStatus(ActionItem.ApprovalStatus.PENDING)
+            .build();
+
+        decision = Decision.builder()
+            .id(UUID.randomUUID())
+            .meeting(meeting)
+            .description("Use Spring Boot")
+            .approvalStatus(Decision.ApprovalStatus.PENDING)
+            .build();
+    }
+
+    @Test
+    @DisplayName("BUG: First approval should NOT mark all items as APPROVED when other members haven't responded yet")
+    void firstApproval_shouldNotApproveAllItems_whenOtherMembersHaveNotResponded() {
+        // Two-member meeting: user1 approves, user2 hasn't responded yet.
+        // Expected: items stay PENDING until ALL members approve.
+        // Actual (bug): items are immediately set to APPROVED after first approval.
+
+        ApprovalResponseSummary user1Response = ApprovalResponseSummary.builder()
+            .id(UUID.randomUUID())
+            .approvalRequest(approvalRequest)
+            .user(user1)
+            .response(ApprovalResponseSummary.ApprovalResponse.PENDING)
+            .build();
+
+        ApprovalResponseSummary user2Response = ApprovalResponseSummary.builder()
+            .id(UUID.randomUUID())
+            .approvalRequest(approvalRequest)
+            .user(user2)
+            .response(ApprovalResponseSummary.ApprovalResponse.PENDING)
+            .build();
+
+        // user1 is a meeting member
+        when(meetingMemberRepository.existsByMeetingIdAndUserId(meetingId, user1.getId())).thenReturn(true);
+        when(meetingRepository.findById(meetingId)).thenReturn(Optional.of(meeting));
+        when(approvalRequestRepository.findByMeetingId(meetingId)).thenReturn(Optional.of(approvalRequest));
+        when(approvalResponseRepository.findByApprovalRequestIdAndUserId(approvalRequest.getId(), user1.getId()))
+            .thenReturn(Optional.of(user1Response));
+        when(approvalResponseRepository.save(any(ApprovalResponseSummary.class)))
+            .thenAnswer(i -> i.getArgument(0));
+
+        // After user1 approves, user2 is still PENDING — not all have responded
+        when(approvalResponseRepository.findByApprovalRequestId(approvalRequest.getId()))
+            .thenReturn(List.of(user1Response, user2Response));
+
+        when(actionItemRepository.findByMeetingId(meetingId)).thenReturn(List.of(actionItem));
+        when(decisionRepository.findByMeetingId(meetingId)).thenReturn(List.of(decision));
+
+        // Submit user1's APPROVED response
+        SubmitApprovalRequest request = SubmitApprovalRequest.builder()
+            .response("APPROVED")
+            .comments("Looks good")
+            .build();
+
+        approvalService.submitApproval(meetingId, user1, request);
+
+        // ASSERTION: Items should still be PENDING because user2 hasn't approved yet.
+        // This test FAILS because of the bug on line 68-69 that immediately approves all items.
+        assertThat(actionItem.getApprovalStatus())
+            .as("Action item should stay PENDING until ALL members approve, not just the first one")
+            .isEqualTo(ActionItem.ApprovalStatus.PENDING);
+
+        assertThat(decision.getApprovalStatus())
+            .as("Decision should stay PENDING until ALL members approve, not just the first one")
+            .isEqualTo(Decision.ApprovalStatus.PENDING);
+
+        // approveAllSummaryItems should NOT have been called yet
+        verify(actionItemRepository, never()).saveAll(any());
+        verify(decisionRepository, never()).saveAll(any());
+    }
+}

--- a/backend/src/test/java/com/flowboard/service/ChangeApplicationServiceBugTest.java
+++ b/backend/src/test/java/com/flowboard/service/ChangeApplicationServiceBugTest.java
@@ -1,0 +1,190 @@
+package com.flowboard.service;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.flowboard.entity.*;
+import com.flowboard.repository.*;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.*;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+/**
+ * Bug-finding tests for ChangeApplicationService.
+ *
+ * BUG 1: applyDeleteCard() calls cardRepository.delete() (hard delete) while
+ * the rest of the codebase consistently uses soft delete via isDeletionMarked.
+ * This breaks audit trails, cascades unexpectedly, and makes deletion
+ * irreversible — contrary to the soft-delete pattern used everywhere else.
+ *
+ * BUG 2: applyUpdateCard() silently appends " (Updated)" to a card's title
+ * when neither afterState nor beforeState contains a "title" field. This is
+ * invisible data corruption — the caller never requested a title change.
+ */
+@ExtendWith(MockitoExtension.class)
+class ChangeApplicationServiceBugTest {
+
+    @Mock private ChangeRepository changeRepository;
+    @Mock private BoardRepository boardRepository;
+    @Mock private StageRepository stageRepository;
+    @Mock private CardRepository cardRepository;
+    @Mock private UserRepository userRepository;
+    @Mock private ProjectMemberRepository projectMemberRepository;
+    @Mock private ChangeSnapshotRepository changeSnapshotRepository;
+    @Mock private ChangeAuditEntryRepository changeAuditEntryRepository;
+
+    private ChangeApplicationService changeApplicationService;
+    private ObjectMapper objectMapper;
+
+    private User owner;
+    private Project project;
+    private Meeting meeting;
+    private Board board;
+    private Stage stage;
+
+    @BeforeEach
+    void setUp() {
+        objectMapper = new ObjectMapper();
+        changeApplicationService = new ChangeApplicationService(
+            changeRepository,
+            boardRepository,
+            stageRepository,
+            cardRepository,
+            userRepository,
+            projectMemberRepository,
+            changeSnapshotRepository,
+            changeAuditEntryRepository,
+            objectMapper
+        );
+
+        owner = User.builder().id(UUID.randomUUID()).username("owner").email("owner@test.com").build();
+
+        project = Project.builder()
+            .id(UUID.randomUUID())
+            .name("Test Project")
+            .owner(owner)
+            .build();
+
+        meeting = Meeting.builder()
+            .id(UUID.randomUUID())
+            .project(project)
+            .title("Sprint")
+            .status(Meeting.MeetingStatus.APPROVED)
+            .createdBy(owner)
+            .build();
+
+        board = Board.builder()
+            .id(UUID.randomUUID())
+            .name("Main Board")
+            .project(project)
+            .build();
+
+        stage = Stage.builder()
+            .id(UUID.randomUUID())
+            .title("To Do")
+            .board(board)
+            .position(0)
+            .cards(new ArrayList<>())
+            .build();
+    }
+
+    @Test
+    @DisplayName("BUG: DELETE_CARD should soft-delete (set isDeletionMarked) instead of hard-deleting")
+    void applyChange_deleteCard_shouldSoftDelete_notHardDelete() {
+        UUID cardId = UUID.randomUUID();
+        Card card = Card.builder()
+            .id(cardId)
+            .title("Task to delete")
+            .stage(stage)
+            .priority(Card.Priority.MEDIUM)
+            .position(0)
+            .isDeletionMarked(false)
+            .build();
+
+        String beforeState = "{\"id\":\"" + cardId + "\",\"title\":\"Task to delete\"}";
+
+        Change change = Change.builder()
+            .id(UUID.randomUUID())
+            .meeting(meeting)
+            .changeType(Change.ChangeType.DELETE_CARD)
+            .beforeState(beforeState)
+            .afterState("{}")
+            .status(Change.ChangeStatus.APPROVED)
+            .build();
+
+        when(changeRepository.findById(change.getId())).thenReturn(Optional.of(change));
+        when(changeRepository.save(any(Change.class))).thenAnswer(i -> i.getArgument(0));
+        when(boardRepository.findByProjectId(project.getId())).thenReturn(List.of(board));
+        when(cardRepository.findById(cardId)).thenReturn(Optional.of(card));
+        when(changeSnapshotRepository.save(any(ChangeSnapshot.class))).thenAnswer(i -> i.getArgument(0));
+        when(changeAuditEntryRepository.save(any(ChangeAuditEntry.class))).thenAnswer(i -> i.getArgument(0));
+
+        changeApplicationService.applyChange(change.getId(), owner);
+
+        // ASSERTION: Card should be soft-deleted (isDeletionMarked = true), NOT hard-deleted.
+        // This test FAILS because applyDeleteCard() calls cardRepository.delete(card)
+        // instead of setting isDeletionMarked and saving.
+        verify(cardRepository, never()).delete(any(Card.class));
+        verify(cardRepository).save(argThat(c ->
+            Boolean.TRUE.equals(c.getIsDeletionMarked())
+        ));
+    }
+
+    @Test
+    @DisplayName("BUG: UPDATE_CARD should not mutate title when no title field is in the change payload")
+    void applyChange_updateCard_shouldNotMutateTitle_whenNoTitleInPayload() {
+        UUID cardId = UUID.randomUUID();
+        String originalTitle = "Original Task Title";
+
+        Card card = Card.builder()
+            .id(cardId)
+            .title(originalTitle)
+            .description("Some description")
+            .stage(stage)
+            .priority(Card.Priority.MEDIUM)
+            .position(0)
+            .build();
+
+        // Payload only changes description — no "title" field at all.
+        String beforeState = "{\"id\":\"" + cardId + "\"}";
+        String afterState = "{\"id\":\"" + cardId + "\",\"description\":\"Updated description\"}";
+
+        Change change = Change.builder()
+            .id(UUID.randomUUID())
+            .meeting(meeting)
+            .changeType(Change.ChangeType.UPDATE_CARD)
+            .beforeState(beforeState)
+            .afterState(afterState)
+            .status(Change.ChangeStatus.APPROVED)
+            .build();
+
+        when(changeRepository.findById(change.getId())).thenReturn(Optional.of(change));
+        when(changeRepository.save(any(Change.class))).thenAnswer(i -> i.getArgument(0));
+        when(boardRepository.findByProjectId(project.getId())).thenReturn(List.of(board));
+        when(cardRepository.findById(cardId)).thenReturn(Optional.of(card));
+        when(cardRepository.save(any(Card.class))).thenAnswer(i -> i.getArgument(0));
+        when(changeSnapshotRepository.save(any(ChangeSnapshot.class))).thenAnswer(i -> i.getArgument(0));
+        when(changeAuditEntryRepository.save(any(ChangeAuditEntry.class))).thenAnswer(i -> i.getArgument(0));
+
+        changeApplicationService.applyChange(change.getId(), owner);
+
+        // ASSERTION: Title should remain unchanged — the payload didn't request a title change.
+        // This test FAILS because applyUpdateCard() appends " (Updated)" to the title
+        // when neither afterState nor beforeState has a "title" key (line 167-168).
+        ArgumentCaptor<Card> cardCaptor = ArgumentCaptor.forClass(Card.class);
+        verify(cardRepository).save(cardCaptor.capture());
+
+        assertThat(cardCaptor.getValue().getTitle())
+            .as("Card title should remain '%s' when payload has no title field, but got '%s'",
+                originalTitle, cardCaptor.getValue().getTitle())
+            .isEqualTo(originalTitle);
+    }
+}

--- a/backend/src/test/java/com/flowboard/service/ChangePreviewServiceBugTest.java
+++ b/backend/src/test/java/com/flowboard/service/ChangePreviewServiceBugTest.java
@@ -1,0 +1,145 @@
+package com.flowboard.service;
+
+import com.flowboard.dto.ChangeImpactDTO;
+import com.flowboard.dto.ChangeDTO;
+import com.flowboard.entity.*;
+import com.flowboard.repository.ChangeAuditEntryRepository;
+import com.flowboard.repository.ChangeRepository;
+import com.flowboard.repository.MeetingMemberRepository;
+import com.flowboard.repository.ProjectMemberRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.when;
+
+/**
+ * Bug-finding tests for ChangePreviewService.
+ *
+ * BUG 1: extractLikelyCardId() returns hardcoded placeholder strings like
+ * "card-referenced-in-after-state" instead of parsing the actual card UUID
+ * from the JSON payload. Clients receive useless data in the impact analysis.
+ *
+ * BUG 2: hasProjectAccess() only checks the project_members table via
+ * projectMemberRepository.findMemberRole(). It does NOT check whether the
+ * user is the Project.owner. If the owner doesn't have a project_members row,
+ * they are locked out of their own project's changes.
+ */
+@ExtendWith(MockitoExtension.class)
+class ChangePreviewServiceBugTest {
+
+    @Mock private ChangeRepository changeRepository;
+    @Mock private ChangeAuditEntryRepository changeAuditEntryRepository;
+    @Mock private MeetingMemberRepository meetingMemberRepository;
+    @Mock private ProjectMemberRepository projectMemberRepository;
+
+    private ChangePreviewService changePreviewService;
+
+    private User owner;
+    private User member;
+    private Project project;
+    private Meeting meeting;
+    private UUID meetingId;
+
+    @BeforeEach
+    void setUp() {
+        changePreviewService = new ChangePreviewService(
+            changeRepository,
+            changeAuditEntryRepository,
+            meetingMemberRepository,
+            projectMemberRepository
+        );
+
+        owner = User.builder().id(UUID.randomUUID()).username("owner").email("owner@test.com").build();
+        member = User.builder().id(UUID.randomUUID()).username("member").email("member@test.com").build();
+
+        project = Project.builder()
+            .id(UUID.randomUUID())
+            .name("Test Project")
+            .owner(owner)
+            .build();
+
+        meetingId = UUID.randomUUID();
+        meeting = Meeting.builder()
+            .id(meetingId)
+            .project(project)
+            .title("Sprint")
+            .status(Meeting.MeetingStatus.PENDING_APPROVAL)
+            .createdBy(owner)
+            .build();
+    }
+
+    @Test
+    @DisplayName("BUG: getImpact() should return actual card UUID from JSON, not a hardcoded placeholder")
+    void getImpact_shouldReturnActualCardId_notPlaceholderString() {
+        // afterState contains a real card UUID, but extractLikelyCardId returns
+        // "card-referenced-in-after-state" instead of the actual UUID.
+        UUID realCardId = UUID.randomUUID();
+        String afterState = "{\"id\":\"" + realCardId + "\",\"title\":\"Fix login\"}";
+
+        Change change = Change.builder()
+            .id(UUID.randomUUID())
+            .meeting(meeting)
+            .changeType(Change.ChangeType.UPDATE_CARD)
+            .afterState(afterState)
+            .status(Change.ChangeStatus.PENDING)
+            .build();
+
+        when(changeRepository.findById(change.getId())).thenReturn(Optional.of(change));
+        when(meetingMemberRepository.existsByMeetingIdAndUserId(meetingId, member.getId())).thenReturn(true);
+
+        ChangeImpactDTO impact = changePreviewService.getImpact(change.getId(), member.getId());
+
+        // ASSERTION: affectedCards should contain the actual card UUID from the JSON.
+        // This test FAILS because extractLikelyCardId returns "card-referenced-in-after-state".
+        assertThat(impact.getAffectedCards())
+            .as("Impact analysis should return the actual card UUID, not a hardcoded placeholder")
+            .contains(realCardId.toString());
+
+        assertThat(impact.getAffectedCards())
+            .as("Should not contain placeholder strings")
+            .noneMatch(s -> s.startsWith("card-referenced-in-"));
+    }
+
+    @Test
+    @DisplayName("BUG: Project owner should be able to list changes even without a project_members row")
+    void listChanges_byProject_shouldAllowProjectOwner_evenWithoutMemberRow() {
+        // The project owner has NO entry in the project_members table.
+        // hasProjectAccess() only checks projectMemberRepository.findMemberRole(),
+        // so the owner is locked out of their own project's changes.
+
+        UUID projectId = project.getId();
+
+        // Owner has no project_members row
+        when(projectMemberRepository.findMemberRole(projectId, owner.getId())).thenReturn(Optional.empty());
+
+        Change change = Change.builder()
+            .id(UUID.randomUUID())
+            .meeting(meeting)
+            .changeType(Change.ChangeType.CREATE_CARD)
+            .afterState("{\"title\":\"New task\"}")
+            .status(Change.ChangeStatus.PENDING)
+            .build();
+
+        when(changeRepository.findByMeetingProjectId(projectId)).thenReturn(List.of(change));
+
+        // ASSERTION: Owner should have access to their own project's changes.
+        // This test FAILS because hasProjectAccess() doesn't check the owner field.
+        // It throws FORBIDDEN instead.
+        List<ChangeDTO> changes = changePreviewService.listChanges(null, projectId, null, owner.getId());
+
+        assertThat(changes)
+            .as("Project owner should be able to list their project's changes")
+            .hasSize(1);
+    }
+}

--- a/backend/src/test/java/com/flowboard/service/MeetingServiceBugTest.java
+++ b/backend/src/test/java/com/flowboard/service/MeetingServiceBugTest.java
@@ -1,0 +1,109 @@
+package com.flowboard.service;
+
+import com.flowboard.entity.*;
+import com.flowboard.repository.*;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.time.LocalDate;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.when;
+
+/**
+ * Bug-finding tests for MeetingService.
+ *
+ * BUG: deleteMeeting() only verifies that the actor is a project member.
+ * It does NOT check that the actor is the project owner or the meeting creator.
+ * This means any project member — even a viewer with no edit privileges — can
+ * delete any SCHEDULED meeting in the project.
+ */
+@ExtendWith(MockitoExtension.class)
+class MeetingServiceBugTest {
+
+    @Mock private MeetingRepository meetingRepository;
+    @Mock private MeetingMemberRepository meetingMemberRepository;
+    @Mock private ProjectRepository projectRepository;
+    @Mock private ProjectMemberRepository projectMemberRepository;
+    @Mock private UserRepository userRepository;
+
+    private MeetingService meetingService;
+
+    private User owner;
+    private User viewer;
+    private Project project;
+    private Meeting meeting;
+
+    @BeforeEach
+    void setUp() {
+        meetingService = new MeetingService(
+            meetingRepository,
+            meetingMemberRepository,
+            projectRepository,
+            projectMemberRepository,
+            userRepository
+        );
+
+        owner = User.builder().id(UUID.randomUUID()).username("owner").email("owner@test.com").build();
+        viewer = User.builder().id(UUID.randomUUID()).username("viewer").email("viewer@test.com").build();
+
+        project = Project.builder()
+            .id(UUID.randomUUID())
+            .name("Test Project")
+            .owner(owner)
+            .build();
+
+        meeting = Meeting.builder()
+            .id(UUID.randomUUID())
+            .project(project)
+            .title("Sprint Planning")
+            .meetingDate(LocalDate.now().plusDays(7))
+            .status(Meeting.MeetingStatus.SCHEDULED)
+            .createdBy(owner)
+            .build();
+    }
+
+    @Test
+    @DisplayName("BUG: Viewer-role project member should NOT be able to delete meetings")
+    void deleteMeeting_shouldRejectViewerRole() {
+        // The viewer is a project member with "viewer" role — no edit privileges.
+        // They should NOT be allowed to delete a meeting.
+
+        when(meetingRepository.findById(meeting.getId())).thenReturn(Optional.of(meeting));
+        // Viewer is a project member with viewer role
+        when(projectMemberRepository.findMemberRole(project.getId(), viewer.getId()))
+            .thenReturn(Optional.of("viewer"));
+
+        // ASSERTION: Should throw FORBIDDEN because viewers can't delete meetings.
+        // This test FAILS because deleteMeeting() only checks project membership,
+        // not the member's role. Any project member can delete any scheduled meeting.
+        assertThatThrownBy(() -> meetingService.deleteMeeting(meeting.getId(), viewer))
+            .isInstanceOf(ResponseStatusException.class)
+            .hasMessageContaining("Forbidden");
+    }
+
+    @Test
+    @DisplayName("BUG: Non-creator project member should NOT be able to delete meetings they didn't create")
+    void deleteMeeting_shouldRejectNonCreator_evenIfEditor() {
+        // An editor-role project member who did NOT create the meeting
+        // tries to delete it. Only the creator or owner should be able to.
+        User editor = User.builder().id(UUID.randomUUID()).username("editor").email("editor@test.com").build();
+
+        when(meetingRepository.findById(meeting.getId())).thenReturn(Optional.of(meeting));
+        when(projectMemberRepository.findMemberRole(project.getId(), editor.getId()))
+            .thenReturn(Optional.of("editor"));
+
+        // ASSERTION: Editor who isn't the meeting creator or project owner should be rejected.
+        // This test FAILS because deleteMeeting() allows any project member to delete.
+        assertThatThrownBy(() -> meetingService.deleteMeeting(meeting.getId(), editor))
+            .isInstanceOf(ResponseStatusException.class)
+            .hasMessageContaining("Forbidden");
+    }
+}


### PR DESCRIPTION
## Summary
- Add 4 new test files with **intentionally failing** tests that expose **6 real bugs** across backend services
- Fix Lombok annotation processing config in `pom.xml` (bump to 1.18.34 + add `maven-compiler-plugin` processor paths)

## Bugs Exposed

| # | Service | Bug | Severity |
|---|---------|-----|----------|
| 1 | `ApprovalService` | `submitApproval()` calls `approveAllSummaryItems()` on the **first** approval, violating the "all must approve" consensus model. Items are marked APPROVED before other members respond. | HIGH |
| 2 | `ChangePreviewService` | `extractLikelyCardId()` returns hardcoded placeholders (`"card-referenced-in-after-state"`) instead of parsing actual card UUIDs from JSON. Impact analysis endpoint returns useless data. | MEDIUM |
| 3 | `ChangePreviewService` | `hasProjectAccess()` only checks `project_members` table — does **not** check `Project.owner`. Owners without a `project_members` row are locked out of their own project's changes. | HIGH |
| 4 | `ChangeApplicationService` | `applyDeleteCard()` uses `cardRepository.delete()` (hard delete) while the rest of the codebase uses soft delete via `isDeletionMarked`. | MEDIUM |
| 5 | `ChangeApplicationService` | `applyUpdateCard()` silently appends `" (Updated)"` to a card's title when neither `afterState` nor `beforeState` has a `title` field — invisible data corruption. | MEDIUM |
| 6 | `MeetingService` | `deleteMeeting()` only checks project membership, not role. Any member (including viewers) can delete any scheduled meeting. | HIGH |

## Test Files
- `ApprovalServiceBugTest.java` — Bug #1
- `ChangePreviewServiceBugTest.java` — Bugs #2, #3
- `ChangeApplicationServiceBugTest.java` — Bugs #4, #5
- `MeetingServiceBugTest.java` — Bug #6

## Test plan
- [ ] All 6 tests should **fail** on the current codebase, confirming the bugs exist
- [ ] CI backend job runs `mvn clean verify` which will compile and execute these tests
- [ ] After each bug is fixed, the corresponding test should turn green

🤖 Generated with [Claude Code](https://claude.com/claude-code)