### PR TITLE
docs: add red-team findings for auth logging gaps

### DIFF
--- a/red-team-findings.md
+++ b/red-team-findings.md
@@ -1,0 +1,21 @@
+# Red Team Findings
+
+## Finding: Silent Security Perimeter in Authentication Flow
+
+### Weakness
+`AuthController`, `AuthService`, and `JWTAuthenticationFilter` currently have no logging.
+
+Every other service layer has `@Slf4j` plus meaningful log statements, but the entire security perimeter is effectively silent. In production, this means:
+
+- Failed logins are never recorded.
+- JWT validation failures leave no trace.
+- Brute-force attacks are undetectable.
+- No audit trail exists for authentication-protected API endpoint access.
+
+### How To Fix
+- Add `@Slf4j` to `AuthService` and log `warn` on failed login attempts.
+- Log JWT parse and validation exceptions in `JWTAuthenticationFilter`.
+- Enable `CommonsRequestLoggingFilter` for HTTP-level audit logging.
+
+## Co-Author
+Co-authored-by: Saanvi Elaty <elatysaanvi@gmail.com>


### PR DESCRIPTION
Added a file with recommended changes 
Weakness
AuthController, AuthService, and JWTAuthenticationFilter have
zero logging. Every other service layer has @Slf4j + log statements,
but the entire security perimeter is silent. In production this means:

Failed logins are never recorded
JWT validation failures leave no trace
Brute-force attacks are undetectable
No audit trail for any API endpoint

How to fix
Add @Slf4j to AuthService, log warn on failed login attempts
Log JWT parse exceptions in JWTAuthenticationFilter
Enable CommonsRequestLoggingFilter for HTTP-level audit logging

Co-authored-by: Saanvi Elaty <elatysaanvi@gmail.com>